### PR TITLE
CircleCI Scheduler at 9 a.m. EST

### DIFF
--- a/.github/workflows/circleci-scheduler.yml
+++ b/.github/workflows/circleci-scheduler.yml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # Everday at 9:00 AM
-    - cron:  '0 9 * * *'
+    # Every day at 2 p.m. UTC (9 a.m. EST)
+    - cron:  '0 14 * * *'
 
 name: CircleCI Scheduler
 jobs:


### PR DESCRIPTION
The scheduling uses UTC. This updates the scheduler to run at 9 a.m. EST.